### PR TITLE
translated title of reset password email devise default titles are in…

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Locavelow : Votre demande de réinitialisation de mot de passe."
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:


### PR DESCRIPTION
- just a simple translation of title that was not visible in gem letter_opener but appeared in prod (reset password instructions email)